### PR TITLE
fix: ignore non-numeric default value for Float field (#49)

### DIFF
--- a/src/ElasticApiParser.js
+++ b/src/ElasticApiParser.js
@@ -323,6 +323,11 @@ export default class ElasticApiParser {
 
     if (paramCfg.default) {
       result.defaultValue = paramCfg.default;
+      // Handle broken data where default is not valid for the given type
+      // https://github.com/graphql-compose/graphql-compose-elasticsearch/issues/49
+      if (result.type === 'Float' && Number.isNaN(Number(paramCfg.default))) {
+        delete result.defaultValue;
+      }
     } else if (fieldName === 'format') {
       result.defaultValue = 'json';
     }

--- a/src/__tests__/ElasticApiParser-test.js
+++ b/src/__tests__/ElasticApiParser-test.js
@@ -377,6 +377,12 @@ describe('ElasticApiParser', () => {
         defaultValue: 'json',
       });
     });
+
+    it('should ignore non-numeric default for float', () => {
+      expect(
+        parser.paramToGraphQLArgConfig({ type: 'number', default: 'ABC' }, 'someField')
+      ).not.toHaveProperty('defaultValue');
+    });
   });
 
   describe('settingsToArgMap()', () => {


### PR DESCRIPTION
This is not particularly general, but it does seem to remove the errors from the graphql response.