### PR TITLE
refactor(ElasticApiParser): Add test for float with valid value as string

### DIFF
--- a/src/ElasticApiParser.js
+++ b/src/ElasticApiParser.js
@@ -323,10 +323,15 @@ export default class ElasticApiParser {
 
     if (paramCfg.default) {
       result.defaultValue = paramCfg.default;
-      // Handle broken data where default is not valid for the given type
-      // https://github.com/graphql-compose/graphql-compose-elasticsearch/issues/49
-      if (result.type === 'Float' && Number.isNaN(Number(paramCfg.default))) {
-        delete result.defaultValue;
+      if (result.type === 'Float') {
+        const defaultNumber = Number(result.defaultValue);
+        if (Number.isNaN(defaultNumber)) {
+          // Handle broken data where default is not valid for the given type
+          // https://github.com/graphql-compose/graphql-compose-elasticsearch/issues/49
+          delete result.defaultValue;
+        } else {
+          result.defaultValue = defaultNumber;
+        }
       }
     } else if (fieldName === 'format') {
       result.defaultValue = 'json';

--- a/src/__tests__/ElasticApiParser-test.js
+++ b/src/__tests__/ElasticApiParser-test.js
@@ -383,6 +383,12 @@ describe('ElasticApiParser', () => {
         parser.paramToGraphQLArgConfig({ type: 'number', default: 'ABC' }, 'someField')
       ).not.toHaveProperty('defaultValue');
     });
+
+    it('should accept numeric default for float', () => {
+      expect(
+        parser.paramToGraphQLArgConfig({ type: 'number', default: '4.2' }, 'someField')
+      ).toHaveProperty('defaultValue', 4.2);
+    });
   });
 
   describe('settingsToArgMap()', () => {


### PR DESCRIPTION
Valid number encoded as string gets parsed and retained