### PR TITLE
Rename underscored to dots for nested queries

### DIFF
--- a/src/elasticDSL/Query/Query.js
+++ b/src/elasticDSL/Query/Query.js
@@ -118,6 +118,9 @@ export function prepareQueryInResolve(
   if (query.bool) {
     query.bool = prepareBoolInResolve(query.bool, fieldMap);
   }
+  if (query.nested && query.nested.query) {
+    query.nested.query = prepareQueryInResolve(query.nested.query, fieldMap);
+  }
   if (query.constant_score) {
     query.constant_score = prepareConstantScoreInResolve(query.constant_score, fieldMap);
   }


### PR DESCRIPTION
Currently nested queries do not get converted. This PR fixes it.