### PR TITLE
Fix #60

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,28 +38,25 @@ export function prepareCommonOpts<TContext>(
     schemaComposer,
     getOrCreateOTC: (typeName, cfgOrThunk) => {
       return schemaComposer.getOrSet(typeName, () => {
-        const tc = schemaComposer.createObjectTC(typeName);
-        const cfg = isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk;
-        tc.setFields(cfg.fields);
-        tc.setDescription(cfg.description);
+        const tc = schemaComposer.createObjectTC(
+          isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk
+        );
         return tc;
       });
     },
     getOrCreateITC: (typeName, cfgOrThunk) => {
       return schemaComposer.getOrSet(typeName, () => {
-        const tc = schemaComposer.createInputTC(typeName);
-        const cfg = isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk;
-        tc.setFields(cfg.fields);
-        tc.setDescription(cfg.description);
+        const tc = schemaComposer.createInputTC(
+          isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk
+        );
         return tc;
       });
     },
     getOrCreateETC: (typeName, cfgOrThunk) => {
       return schemaComposer.getOrSet(typeName, () => {
-        const tc = schemaComposer.createEnumTC(typeName);
-        const cfg = isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk;
-        tc.setFields(cfg.values);
-        tc.setDescription(cfg.description);
+        const tc = schemaComposer.createEnumTC(
+          isFunction(cfgOrThunk) ? (cfgOrThunk: any)() : cfgOrThunk
+        );
         return tc;
       });
     },


### PR DESCRIPTION
Fixes a regression introduced in `v3.1`. `schemaComposer.createObjectTC` accepts a `typeDef`, which could be a `string` (as in https://github.com/graphql-compose/graphql-compose-elasticsearch/blob/v3.1.1/src/resolvers/searchConnection.js#L141). `cfg` does not have `field` attributes in this case, causing `PageInfo` to be empty.