### PR TITLE
Support for Elasticsearch "Collapse" query

### DIFF
--- a/src/elasticDSL/SearchBody.ts
+++ b/src/elasticDSL/SearchBody.ts
@@ -20,6 +20,7 @@ export function getSearchBodyITC<TContext>(
     description,
     fields: {
       query: { type: () => getQueryITC(opts) },
+      collapse: 'JSON',
       aggs: { type: () => getAggsITC(opts) },
       size: 'Int',
       from: 'Int',

--- a/src/resolvers/search.ts
+++ b/src/resolvers/search.ts
@@ -66,9 +66,10 @@ export default function createSearchResolver<TSource, TContext>(
   argsConfigMap.query = searchITC.getField('query');
   argsConfigMap.aggs = searchITC.getField('aggs');
   argsConfigMap.sort = searchITC.getField('sort');
+  argsConfigMap.collapse = searchITC.getField('collapse');
   argsConfigMap.highlight = searchITC.getField('highlight');
 
-  const topLevelArgs = ['q', 'query', 'sort', 'limit', 'skip', 'aggs', 'highlight', 'opts'];
+  const topLevelArgs = ['q', 'query', 'collapse', 'sort', 'limit', 'skip', 'aggs', 'highlight', 'opts'];
   argsConfigMap.opts = schemaComposer
     .createInputTC({
       name: `${sourceTC.getTypeName()}Opts`,
@@ -145,6 +146,11 @@ export default function createSearchResolver<TSource, TContext>(
           args.body.query = args.query;
           delete args.query;
         }
+        
+        if (args.collapse) {
+          args.body.collapse = args.collapse;
+          delete args.collapse;
+        }
 
         if (args.aggs) {
           args.body.aggs = args.aggs;
@@ -191,7 +197,7 @@ export default function createSearchResolver<TSource, TContext>(
         return res;
       },
     })
-    .reorderArgs(['q', 'query', 'sort', 'limit', 'skip', 'aggs']);
+    .reorderArgs(['q', 'query', 'collapse', 'sort', 'limit', 'skip', 'aggs']);
 }
 
 export function toDottedList(projection: ProjectionType, prev?: string[]): string[] | boolean {

--- a/src/types/SearchHitItem.ts
+++ b/src/types/SearchHitItem.ts
@@ -31,6 +31,11 @@ export function getSearchHitItemTC<TContext>(
 
       _version: 'Int',
 
+      inner_hits: {
+        type: 'JSON',
+        description: 'Returns data only if `args.collapse` is provided',
+      },
+      
       highlight: {
         type: 'JSON',
         description: 'Returns data only if `args.highlight` is provided',


### PR DESCRIPTION
I have run and tested this code on my local system but was hoping to get this incorporated into the main repo. I have gotten a lot of use out of this tool and would like to also have the ability to perform elasticsearch [Collapse ](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html) queries.

It's a pretty basic field that I modeled after "highlight".  

Please let me know what I need to do to get this approved for merge.


Sample Query:

```typescript
elasticSearch(
    query: {
      bool: {
        must: {
          match_all: {}
        }, 
        filter: [
          {range: { timestamp: { "gte": 1642014000000,  "lte": 1642104000000 }}}
        ]
      }
    },
    collapse: {
      field: "user_id"
    },
    sort: [timestamp__desc]
  ) {
    count
    hits {
      _source {
        timestamp
        user_id
      }
    }
  }
```