### PR TITLE
Update Aggs - replace __ with [.dot] recursively

### DIFF
--- a/src/elasticDSL/Aggs/Aggs.ts
+++ b/src/elasticDSL/Aggs/Aggs.ts
@@ -52,8 +52,12 @@ export function convertAggsRules(rules: GqlAggRules): ElasticAggsRulesT {
   Object.keys(rules).forEach((key) => {
     if (key === 'aggs' && rules.aggs) {
       result.aggs = convertAggsBlocks(rules.aggs);
-    } else {
-      result[key] = rules[key];
+    } else if(Array.isArray(rules[key])) {
+      result[key.replace(/__/g, '.')] = rules[key].map(rule => convertAggsRules(rule))
+    } else if(typeof rules[key] === 'object') {
+      result[key.replace(/__/g, '.')] = convertAggsRules(rules[key]);
+    }else {
+      result[key.replace(/__/g, '.')] = rules[key];
     }
   });
   return result;

--- a/src/elasticDSL/Aggs/Aggs.ts
+++ b/src/elasticDSL/Aggs/Aggs.ts
@@ -52,11 +52,11 @@ export function convertAggsRules(rules: GqlAggRules): ElasticAggsRulesT {
   Object.keys(rules).forEach((key) => {
     if (key === 'aggs' && rules.aggs) {
       result.aggs = convertAggsBlocks(rules.aggs);
-    } else if(Array.isArray(rules[key])) {
-      result[key.replace(/__/g, '.')] = rules[key].map(rule => convertAggsRules(rule))
-    } else if(typeof rules[key] === 'object') {
+    } else if (Array.isArray(rules[key])) {
+      result[key.replace(/__/g, '.')] = rules[key].map((rule) => convertAggsRules(rule));
+    } else if (typeof rules[key] === 'object') {
       result[key.replace(/__/g, '.')] = convertAggsRules(rules[key]);
-    }else {
+    } else {
       result[key.replace(/__/g, '.')] = rules[key];
     }
   });


### PR DESCRIPTION
Nested keys with __ are not transformed

for e.g,
`filter: {
          bool: {
            filter: [
              {
                nested: {
                  path: "string_facets"
                  query: {
                    bool: {
                      filter: [
                        {
                          terms: { string_facets__facet_name: { value: "make" } }
                        }
                        {
                          terms: {
                            string_facets__facet_value: { value: "Omron" }
                          }
                        }
                      ]
                    }
                  }
                }
              }
              {
                nested: {
                  path: "string_facets"
                  query: {
                    bool: {
                      filter: [
                        {
                          term: { string_facets__facet_name: { value: "roHs" } }
                        }
                        {
                          term: {
                            string_facets__facet_value: { value: "Compliant" }
                          }
                        }
                      ]
                    }
                  }
                }
              }
            ]
          }
        }`
        
        were not replaced with dots, as we were having the rules passed in, as it is,