### PR TITLE
Fix broken typescript compilation

### DIFF
--- a/src/ElasticApiParser.ts
+++ b/src/ElasticApiParser.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-/// <reference path="./types.d.ts" />
 
 import dox from 'dox';
 import fs from 'fs';


### PR DESCRIPTION
Typescript breaks on compilation because of an invalid use of reference types, see [this documentation](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) as to why the previous usage of reference types to refer to a relative path is invalid.

```
node_modules/graphql-compose-elasticsearch/lib/ElasticApiParser.d.ts:1:23 - error TS2688: Cannot find type definition file for 'src/types'.

1 /// <reference types="src/types" />
                        ~~~~~~~~~
```

Was able to remove this line locally and re-build and validated that this works fine and solves the build failures.