### PR TITLE
Update Aggs.ts - don't convert strings to objects

### DIFF
--- a/src/elasticDSL/Aggs/Aggs.ts
+++ b/src/elasticDSL/Aggs/Aggs.ts
@@ -48,6 +48,7 @@ export function convertAggsBlocks(blockList: GqlAggBlock[]): ElasticAggsT {
 }
 
 export function convertAggsRules(rules: GqlAggRules): ElasticAggsRulesT {
+  if (typeof rules === 'string') return rules;
   const result = {} as ElasticAggsRulesT;
   Object.keys(rules).forEach((key) => {
     if (key === 'aggs' && rules.aggs) {


### PR DESCRIPTION
This PR fixes the following issue:
https://github.com/graphql-compose/graphql-compose-elasticsearch/issues/145

Expected:
`{ terms: { field: 'source.keyword', exclude: ['Other', 'unknown'] } }`

Actual:
`{ terms: { field: 'source.keyword', exclude: [{0: 'O', 1: 't', 2: 'h', 3: 'e', 4: 'r'}, {0: 'u', 1: 'n', 2: 'k', 3: 'n', 4: 'o', 5: 'w', 6: 'n'}] } }`

This fix will ensure strings are not converted to objects